### PR TITLE
Fix sheet misaligned from right on documentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 

--- a/app/helpers/components/sheet_helper.rb
+++ b/app/helpers/components/sheet_helper.rb
@@ -17,4 +17,13 @@ module Components::SheetHelper
   def sheet_content(&block)
     content_for :sheet_content, capture(&block), flush: true
   end
+
+  def direction_class(direction)
+    mappings = {
+      "left": 'left-0',
+      "right": 'right-0'
+    }
+
+    mappings[direction.to_sym]
+  end
 end

--- a/app/views/components/ui/_sheet.html.erb
+++ b/app/views/components/ui/_sheet.html.erb
@@ -9,7 +9,7 @@
     data-ui--sheet-target="dialog"
     class="data-[state=closed]:hidden data-[state=open]:block fixed z-50 gap-4 bg-background p-6 shadow-lg
         transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500
-        inset-y-0 <%= options[:direction] %>-0 h-full <%= options[:width] %> border-l data-[state=closed]:slide-out-to-<%= options[:direction] %> data-[state=open]:slide-in-from-<%= options[:direction] %> sm:max-w-sm" tabindex="-1"
+        inset-y-0 <%= direction_class(options[:direction]) %> h-full <%= options[:width] %> border-l data-[state=closed]:slide-out-to-<%= options[:direction] %> data-[state=open]:slide-in-from-<%= options[:direction] %> sm:max-w-sm" tabindex="-1"
     style="pointer-events: auto">
       <div data-ui--sheet-target="content"><%= content_for(:sheet_content) %></div>
       <button

--- a/config/shadcn.tailwind.js
+++ b/config/shadcn.tailwind.js
@@ -8,7 +8,6 @@ module.exports = {
     "./app/javascript/**/*.js",
     "./app/views/**/*.{erb,haml,html,slim}",
   ],
-  safelist: ["left-0", "right-0"],
   theme: {
     container: {
       center: true,

--- a/config/shadcn.tailwind.js
+++ b/config/shadcn.tailwind.js
@@ -8,6 +8,7 @@ module.exports = {
     "./app/javascript/**/*.js",
     "./app/views/**/*.{erb,haml,html,slim}",
   ],
+  safelist: ["left-0", "right-0"],
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
As we are utilizing dynamic classes in the sheet component: (<%= options[:direction] %>-0)

The class `right-0` is not recognized by the [Tailwind CSS purge process](https://tailwindcss.com/docs/content-configuration#dynamic-class-names). 


To address this issue, I use a constant in `direction_class` method to encapsulate the direction class names (`left-0` and `right-0`). This approach offers several advantages for future scenarios, especially when we aim to extend support for top and bottom positions.