### PR TITLE
Remove empty ERB tag

### DIFF
--- a/app/views/examples/components/alert/code/_no_icon.erb
+++ b/app/views/examples/components/alert/code/_no_icon.erb
@@ -1,3 +1,3 @@
-<% %><%= render_alert icon: false,
+<%= render_alert icon: false,
       title: "Skip the Icon",
       description: "By setting icon: to false in your render_alert call." %>


### PR DESCRIPTION
Hey 👋 🌊 

This removes the empty ERB tag before the __no_icon.erb_ alert example.

> <img width="641" alt="Screenshot 2023-07-29 at 10 47 09" src="https://github.com/aviflombaum/shadcn-rails/assets/360276/5ebe83e1-76bd-4ef9-93b8-9350b74657c9">
