### PR TITLE
Fix broken link to generators page in installation page

### DIFF
--- a/app/views/documentation/installation.html.md
+++ b/app/views/documentation/installation.html.md
@@ -117,7 +117,7 @@ by being at the end. And obviously feel free to inspect shadcnConfig and keep on
 ## End
 
 That's it! You are now set to start
-[installing components via the generator]("/documentation/generators") and rendering them into your
+[installing components via the generator](/docs/generators) and rendering them into your
 views.
 
 # Manual Installation


### PR DESCRIPTION
## Description

In the installation page, the link to `docs/generators` is broken.

It looks like `https://shadcn.rails-components.com/docs/%22/documentation/generators%22` with the %22 which comes from double quotes in the markdown.

This PR is a simple fix that corrects the link.

**PS:** @aviflombaum we should also add a contributors README and probably check PRs for whether links are referenced correctly. Having well maintained docs will help speed up adoption of this amazing project!

## Images

![CleanShot 2023-08-04 at 15 02 37@2x](https://github.com/aviflombaum/shadcn-rails/assets/1908934/a9214cc7-1b63-47ef-b006-1390807d10b0)
