### PR TITLE
Fix filter component list_item function

### DIFF
--- a/app/helpers/components/filter_helper.rb
+++ b/app/helpers/components/filter_helper.rb
@@ -9,4 +9,8 @@ module Components::FilterHelper
     input_class = content_for?(:filter_icon) ? "pl-1" : ""
     render "components/ui/filter", items: items, options: options, input_class: input_class, content: content
   end
+
+  def list_item(:value, :name, :selected)
+     "#{name}"
+  end
 end


### PR DESCRIPTION
As simple as it gets, just returning `:name`. Fixes #50, with combobox. 