### PR TITLE
fix: fixes syntax error in filter_helper

### DIFF
--- a/app/helpers/components/filter_helper.rb
+++ b/app/helpers/components/filter_helper.rb
@@ -10,7 +10,7 @@ module Components::FilterHelper
     render "components/ui/filter", items: items, options: options, input_class: input_class, content: content
   end
 
-  def list_item(:value, :name, :selected)
+  def list_item(value:, name:, selected:)
      "#{name}"
   end
 end


### PR DESCRIPTION
This pull request is for bug fix #60.
In the `list_item` method of `app/helpers/components/filter_helper.rb`, a part that should be a keyword argument was written as a symbol, causing a Syntax Error.
This fix corrects the notation of symbols as keyword arguments and resolves the problem.