### PR TITLE
Fix syntax error in dropdown menu examples and usage code

### DIFF
--- a/app/views/examples/components/dropdown-menu/code/_preview.erb
+++ b/app/views/examples/components/dropdown-menu/code/_preview.erb
@@ -1,4 +1,4 @@
-<% render_dropdown_menu do %>
+<%= render_dropdown_menu do %>
   <%= dropdown_menu_trigger do %>
     <%= render_button "Open Dropdown", variant: :outline %>
   <% end %>
@@ -8,7 +8,7 @@
     <%= render_separator class: "my-1" %>
     <%= dropdown_menu_item "Profile" %>
     <%= dropdown_menu_item  do %>
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-2 h-4 w-4">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 mr-2">
         <rect width="20" height="14" x="2" y="5" rx="2"></rect><line x1="2" x2="22" y1="10" y2="10"></line>
       </svg>
       <span>Billing</span>

--- a/app/views/examples/components/dropdown-menu/code/_usage.erb
+++ b/app/views/examples/components/dropdown-menu/code/_usage.erb
@@ -1,4 +1,4 @@
-<% render_dropdown_menu do %>
+<%= render_dropdown_menu do %>
   <%= dropdown_menu_trigger do %>
   <% end %>
 


### PR DESCRIPTION
#### Description:
This pull request addresses the issue where the dropdown menu examples and usage code in the documentation use script tags instead of output tags. This prevented the dropdown component from appearing correctly when copied from the documentation.

#### Changes Made:
- Corrected the syntax from script tag `<%` to output tag `<%=` in `app/views/examples/components/dropdown-menu/code/_preview.erb`.
- Corrected the syntax from script tag `<%` to output tag `<%=` in `app/views/examples/components/dropdown-menu/code/_usage.erb`.

#### Affected Files:
- `app/views/examples/components/dropdown-menu/code/_preview.erb`
- `app/views/examples/components/dropdown-menu/code/_usage.erb`

These changes ensure that the dropdown components render correctly when copied from the documentation examples and usage sections.

#### Related Issue:
- This pull request resolves issue #62.