### PR TITLE
Fix class name merging for table helper

### DIFF
--- a/app/helpers/components/table_helper.rb
+++ b/app/helpers/components/table_helper.rb
@@ -1,6 +1,6 @@
 module Components::TableHelper
   def render_table(caption = nil, **options, &block)
-    content_tag :table, options.reverse_merge(
+    content_tag :table, options.merge(
       class: tw("w-full text-sm border-b", options[:class])
     ) do
       if caption.present?
@@ -14,7 +14,7 @@ module Components::TableHelper
   end
 
   def table_head(**options, &block)
-    content_tag :thead, options.reverse_merge(
+    content_tag :thead, options.merge(
       class: tw("[&_tr]:border-b", options[:class])
     ) do
       content_tag :tr, class: "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted" do
@@ -24,7 +24,7 @@ module Components::TableHelper
   end
 
   def table_header(content = nil, **options, &block)
-    content_tag :th, options.reverse_merge(
+    content_tag :th, options.merge(
       class: tw("h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0", options[:class])
     ) do
       if block
@@ -36,19 +36,19 @@ module Components::TableHelper
   end
 
   def table_body(**options, &block)
-    content_tag :tbody, class: options.reverse_merge(
+    content_tag :tbody, class: options.merge(
       class: tw("[&_tr:last-child]:border-0", options[:class])
     ), &block
   end
 
   def table_row(**options, &block)
-    content_tag :tr, options.reverse_merge(
+    content_tag :tr, options.merge(
       class: tw("border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted", options[:class])
     ), &block
   end
 
   def table_column(content = nil, **options, &block)
-    content_tag :td, options.reverse_merge(
+    content_tag :td, options.merge(
       class: tw("p-4 align-middle [&:has([role=checkbox])]:pr-0 font-medium", options[:class])
     ) do
       if block


### PR DESCRIPTION
Previously `options.reverse_merge` would mistakenly not pick the merged classes with the `tw` helper. This was because `reverse_merge` would continue picking the existing classes.

With the change, we pick the new merged classes.