### PR TITLE
Fix class assignment for table_body

### DIFF
--- a/app/helpers/components/table_helper.rb
+++ b/app/helpers/components/table_helper.rb
@@ -36,7 +36,7 @@ module Components::TableHelper
   end
 
   def table_body(**options, &block)
-    content_tag :tbody, class: options.merge(
+    content_tag :tbody, options.merge(
       class: tw("[&_tr:last-child]:border-0", options[:class])
     ), &block
   end


### PR DESCRIPTION
Unlike the rest of the table_* helpers, table_body had mistakenly assigned all options to class. Fixing it so we can pass different parameters.