### PR TITLE
Allow setting `class` of the dialog modal div.

### DIFF
--- a/app/helpers/components/dialog_helper.rb
+++ b/app/helpers/components/dialog_helper.rb
@@ -1,7 +1,7 @@
 module Components::DialogHelper
   def render_dialog(**options, &block)
     content = capture(&block) if block
-    render "components/ui/dialog", content: content, **options
+    render "components/ui/dialog", content: content, options: options
   end
 
   def dialog_trigger(&block)

--- a/app/views/components/ui/_dialog.html.erb
+++ b/app/views/components/ui/_dialog.html.erb
@@ -7,7 +7,7 @@
     role="dialog"
     data-state="closed"
     data-ui--dialog-target="dialog"
-    class="hidden fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full sm:max-w-[425px]"
+    class="<%= tw('hidden fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full sm:max-w-[425px]', options[:class]) %>"
     tabindex="-1"
     style="pointer-events: auto">
       <div><%= content_for(:dialog_content) %></div>


### PR DESCRIPTION
This follows the convention in some of the other components where `options` is passed into the erb as options. I've chose the `:class` here which associates with the dialog modal. This is because the trigger does no existing classes defined and we can introduce a `:trigger_class` in the future if needed.