### PR TITLE
Accordion toggle action should change aria-expanded

### DIFF
--- a/app/javascript/controllers/ui/accordion_controller.js
+++ b/app/javascript/controllers/ui/accordion_controller.js
@@ -71,6 +71,7 @@ export default class extends Controller {
 
     this.toggleClass(toggler, content, true);
     this.toggleText(toggler, true);
+    this.toggleAriaExpanded(toggler, true)
   }
 
   hide(toggler, content, transition = true) {
@@ -85,6 +86,7 @@ export default class extends Controller {
 
     this.toggleClass(toggler, content, false);
     this.toggleText(toggler, false);
+    this.toggleAriaExpanded(toggler, false)
   }
 
   transitionEnd(e) {
@@ -111,6 +113,10 @@ export default class extends Controller {
       text = toggler.getAttribute("data-accordion-closed-text-param");
     }
     if (text) toggler.innerHTML = text;
+  }
+
+  toggleAriaExpanded(toggler, opened) {
+    toggler.ariaExpanded = opened ? "true" : "false";
   }
 
   isOpened(toggler) {

--- a/app/views/components/ui/_accordion.html.erb
+++ b/app/views/components/ui/_accordion.html.erb
@@ -11,7 +11,7 @@
       <a
         href="content-1"
         data-action="ui--accordion#toggle"
-        aria-expanded="true"
+        aria-expanded="false"
         data-orientation="vertical"
         class="flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180">
         <%= title || content_for(:title) %><svg


### PR DESCRIPTION
[According to ARIA-APG](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/#wai-ariaroles,states,andproperties:), the `aria-expanded` attribute on an Accordion Toggle should switch between "true" and "false" depending on panel visibility. 

This pull request fixes this and also aligns better with the Shadcn/UI behaviour.

### Current behaviour

https://github.com/user-attachments/assets/7d1a28b6-a809-4474-8112-9da272f7ae98

### Shadcn/UI behaviour

https://github.com/user-attachments/assets/310f28c8-4070-43bd-8427-92e47ca0449a

### Behaviour after current fix

https://github.com/user-attachments/assets/e313f0b3-3461-4200-b6cb-7aec011ca3c4




