### PR TITLE
Allow opening the dialog by default trough the state parameter

### DIFF
--- a/app/helpers/components/dialog_helper.rb
+++ b/app/helpers/components/dialog_helper.rb
@@ -1,11 +1,12 @@
 module Components::DialogHelper
   def render_dialog(**options, &block)
     content = capture(&block) if block
+    options[:state] = options[:state] || "closed"
     render "components/ui/dialog", content: content, options: options
   end
 
-  def dialog_trigger(&block)
-    content_for :dialog_trigger, capture(&block), flush: true
+  def dialog_trigger(**options, &block)
+    content_for :dialog_trigger, capture(&block), options: options, flush: true
   end
 
   def dialog_content(&block)

--- a/app/javascript/controllers/ui/dialog_controller.js
+++ b/app/javascript/controllers/ui/dialog_controller.js
@@ -11,7 +11,13 @@ export default class UIDialog extends Controller {
   ];
 
   initialize() {}
-  connect() {}
+  
+  connect() {
+    if (this.dialogTarget.dataset.state === "open") {
+      this.openBy(this.dialogTarget);
+    }
+  }
+
   open(e) {
     this.openBy(e.target);
     e.preventDefault();

--- a/app/views/components/ui/_dialog.html.erb
+++ b/app/views/components/ui/_dialog.html.erb
@@ -5,7 +5,7 @@
 
   <div
     role="dialog"
-    data-state="closed"
+    data-state="<%= options[:state] %>"
     data-ui--dialog-target="dialog"
     class="<%= tw('hidden fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full sm:max-w-[425px]', options[:class]) %>"
     tabindex="-1"


### PR DESCRIPTION
Allow to automatically open a dialog when the component renders using  `<%= render_dialog, state: "open" do %>`