### PR TITLE
[ISSUE-21] Prevent focus outside modal

### DIFF
--- a/app/javascript/controllers/ui/dialog_controller.js
+++ b/app/javascript/controllers/ui/dialog_controller.js
@@ -31,6 +31,21 @@ export default class UIDialog extends Controller {
     e.preventDefault();
   }
 
+  handleFocusEvent(e) {
+    let target = this.dialogTarget;
+    let shiftPressed = e.shiftKey;
+    // If TAB is pressed
+    if (e.keyCode === 9) {
+      let focusableElements = target.querySelectorAll("a[href], button");
+      let borderElem = shiftPressed
+        ? focusableElements[0]
+        : focusableElements[focusableElements.length - 1];
+      if (document.activeElement === borderElem) {
+        e.preventDefault();
+      }
+    }
+  }
+
   closeByKey(e) {
     if (e.keyCode == 27) {
       this.closeBy(e.target);

--- a/app/views/components/ui/_dialog.html.erb
+++ b/app/views/components/ui/_dialog.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="ui--dialog">
+<div data-controller="ui--dialog" data-action="keydown->ui--dialog#handleFocusEvent">
   <div data-action="click->ui--dialog#open"><%= content_for(:dialog_trigger) %></div>
 
   <%= render "components/ui/shared/backdrop", as: "modal" %>


### PR DESCRIPTION
Issue: [#21](https://github.com/aviflombaum/shadcn-rails/issues/21)

Prevent focus outside modal by getting focusable elements inside the dialog and removing default behaviour if the next element to focus is out of bounds

![focus](https://github.com/user-attachments/assets/a65ea4f6-6f7f-4ed6-9da6-baf04f6d2a1c)
