### PR TITLE
[ISSUE 12] - Add custom regex pattern to enable custom filtering.

### DIFF
--- a/app/helpers/components/filter_helper.rb
+++ b/app/helpers/components/filter_helper.rb
@@ -4,6 +4,7 @@ module Components::FilterHelper
   end
 
   def render_filter(items, **options, &block)
+    options[:mode] = :starts_with unless [:includes, :starts_with].include?(options[:mode])
     content_for :filter_icon, "", flush: true
     content = capture(&block) if block
     input_class = content_for?(:filter_icon) ? "pl-1" : ""

--- a/app/helpers/components/filter_helper.rb
+++ b/app/helpers/components/filter_helper.rb
@@ -4,7 +4,7 @@ module Components::FilterHelper
   end
 
   def render_filter(items, **options, &block)
-    options[:mode] = :starts_with unless [:includes, :starts_with].include?(options[:mode])
+    options[:pattern] ||= "^{input}"
     content_for :filter_icon, "", flush: true
     content = capture(&block) if block
     input_class = content_for?(:filter_icon) ? "pl-1" : ""

--- a/app/javascript/controllers/ui/filter_controller.js
+++ b/app/javascript/controllers/ui/filter_controller.js
@@ -10,8 +10,7 @@ export default class UIFilter extends Controller {
 
   filter(event) {
     let lowerCaseFilterTerm = this.sourceTarget.value.toLowerCase();
-    const pattern = this.patternValue.replace("{input}", lowerCaseFilterTerm);
-    const regex = new RegExp(pattern);
+    const regex = new RegExp(this.patternValue.replace("{input}", lowerCaseFilterTerm));
     if (this.hasItemTarget) {
       this.itemTargets.forEach((el, i) => {
         let filterableKey = el.innerText.toLowerCase();

--- a/app/javascript/controllers/ui/filter_controller.js
+++ b/app/javascript/controllers/ui/filter_controller.js
@@ -2,18 +2,23 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class UIFilter extends Controller {
   static targets = ["source", "item"];
+  static values = {
+    mode: String,
+  };
 
   connect() {}
 
   filter(event) {
     let lowerCaseFilterTerm = this.sourceTarget.value.toLowerCase();
-    let regex = new RegExp("^" + lowerCaseFilterTerm);
     if (this.hasItemTarget) {
       this.itemTargets.forEach((el, i) => {
         let filterableKey = el.innerText.toLowerCase();
-
+        const shouldToggle =
+          this.modeValue === "includes"
+            ? !filterableKey.trim().includes(lowerCaseFilterTerm)
+            : !filterableKey.trim().startsWith(lowerCaseFilterTerm);
         // Check for consecutive characters match using regex
-        el.classList.toggle("hidden", !regex.test(filterableKey));
+        el.classList.toggle("hidden", shouldToggle);
       });
     }
   }

--- a/app/javascript/controllers/ui/filter_controller.js
+++ b/app/javascript/controllers/ui/filter_controller.js
@@ -3,22 +3,20 @@ import { Controller } from "@hotwired/stimulus";
 export default class UIFilter extends Controller {
   static targets = ["source", "item"];
   static values = {
-    mode: String,
+    pattern: String,
   };
 
   connect() {}
 
   filter(event) {
     let lowerCaseFilterTerm = this.sourceTarget.value.toLowerCase();
+    const pattern = this.patternValue.replace("{input}", lowerCaseFilterTerm);
+    const regex = new RegExp(pattern);
     if (this.hasItemTarget) {
       this.itemTargets.forEach((el, i) => {
         let filterableKey = el.innerText.toLowerCase();
-        const shouldToggle =
-          this.modeValue === "includes"
-            ? !filterableKey.trim().includes(lowerCaseFilterTerm)
-            : !filterableKey.trim().startsWith(lowerCaseFilterTerm);
         // Check for consecutive characters match using regex
-        el.classList.toggle("hidden", shouldToggle);
+        el.classList.toggle("hidden", !regex.test(filterableKey.trim()));
       });
     }
   }

--- a/app/views/components/ui/_filter.html.erb
+++ b/app/views/components/ui/_filter.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="ui--filter">
+<div data-controller="ui--filter" data-ui--filter-mode-value="<%= options[:mode] %>">
   <%= render_card do %>
     <div class="flex items-center">
       <%= content_for :filter_icon %>

--- a/app/views/components/ui/_filter.html.erb
+++ b/app/views/components/ui/_filter.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="ui--filter" data-ui--filter-mode-value="<%= options[:mode] %>">
+<div data-controller="ui--filter" data-ui--filter-pattern-value="<%= options[:pattern] %>">
   <%= render_card do %>
     <div class="flex items-center">
       <%= content_for :filter_icon %>

--- a/app/views/examples/components/filter/_usage.html.erb
+++ b/app/views/examples/components/filter/_usage.html.erb
@@ -10,9 +10,7 @@
 The method <%= code("render_filter") %> method accepts one mandatory argument, an array of hashes that each have a <%= code("value") %> and name <%= code("name") %>.</p>
 
 <p class="leading-7 [&:not(:first-child)]:mt-6">
-You can also use the <%= code("mode") %> argument to specify how filtering should work. The available options are <%= code(":starts_with") %> and <%= code(":includes") %>. 
-By default, the filtering mode will be set to <%= code(":starts_with") %>, which matches items that begin with the specified text. 
-If you prefer to match items containing the specified text anywhere, use <%= code(":includes") %>.
+You can also use the <%= code("pattern") %> argument to provide a regular expression as a string. It requires the placeholder <%=code("{input}") %> to dynamically insert a term into the regex. By default, it is set to <%=code("^{input}") %>, meaning the input term will match only at the beginning of a string. Ensure <%=code("{input}") %> is included in custom patterns to maintain proper functionality.
 </p>
 
 

--- a/app/views/examples/components/filter/_usage.html.erb
+++ b/app/views/examples/components/filter/_usage.html.erb
@@ -7,7 +7,14 @@
 </ul>
 
 <p class="leading-7 [&:not(:first-child)]:mt-6">
-The method <%= code("render_filter") %> method accepts one mandtory argument, an array of hashes that each have a <%= code("value") %> and name <%= code("name") %>.</p>
+The method <%= code("render_filter") %> method accepts one mandatory argument, an array of hashes that each have a <%= code("value") %> and name <%= code("name") %>.</p>
+
+<p class="leading-7 [&:not(:first-child)]:mt-6">
+You can also use the <%= code("mode") %> argument to specify how filtering should work. The available options are <%= code(":starts_with") %> and <%= code(":includes") %>. 
+By default, the filtering mode will be set to <%= code(":starts_with") %>, which matches items that begin with the specified text. 
+If you prefer to match items containing the specified text anywhere, use <%= code(":includes") %>.
+</p>
+
 
 <p class="leading-7 [&:not(:first-child)]:mt-6">You can optionally also call <%= code("filter_icon") %> within a block passed to <%= code("render_filter") %> to render an icon to the left of the filter input.</p>
 


### PR DESCRIPTION
### Issue: #12 

I have added a new property to filter component options hash that enables the user to send a custom RegExp pattern following the next convention:
* It must include  `{input}` placeholder so the controller knows where to put the user input value.`
* If we don't specify a pattern it will default to `"^{input}"`


### Examples:
1. Ends with `render_filter items: items, pattern: "{input}$"`
2. Starts with: `render_filter items: items, pattern: "^{input}"` (This is the default pattern.)
3. Includes: `render_filter items: items, pattern: "{input}"`

