### PR TITLE
Refactored common functionality between dialog controller and sheet controller

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/javascript/controllers/ui/sheet_controller.js
+++ b/app/javascript/controllers/ui/sheet_controller.js
@@ -2,32 +2,25 @@ import UIDialog from "controllers/ui/dialog_controller";
 import "https://ga.jspm.io/npm:@kanety/stimulus-static-actions@1.0.1/dist/index.modern.js";
 
 export default class extends UIDialog {
-  // Handles a button triggering the sheet in a different
-  // controller instance
-  // REFACTOR: This is the toggle method in dialog_controller with dom elements
-  // instead of targets. Update the method there to receive dom elements and this
-  // can be refactored to use those methods instead of reimplementing.
+  /**
+   * Handles a button triggering the sheet in a different controller instance
+   * Uses the common toggleElements method from the parent class
+   */
   toggleOutlet() {
     const sheetTarget = document.querySelector(this.element.dataset.UiSheetOutlet);
     const dialogTarget = sheetTarget.querySelector("[data-ui--sheet-target='dialog']");
     const modalTarget = sheetTarget.querySelector("[data-ui--sheet-target='modal']");
     const contentTarget = sheetTarget.querySelector("[data-ui--sheet-target='content']");
-    const visible = dialogTarget.dataset.state == "closed" ? false : true;
-    const mainTarget = document.body;
-    if (!visible) {
-      document.body.classList.add("overflow-hidden");
-      contentTarget.classList.add("overflow-y-scroll", "h-full");
-      dialogTarget.classList.remove("hidden");
-      dialogTarget.dataset.state = "open";
-      modalTarget.classList.remove("hidden");
-      modalTarget.dataset.state = "open";
-    } else {
-      document.body.classList.remove("overflow-hidden");
-      contentTarget.classList.remove("overflow-y-scroll", "h-full");
-      dialogTarget.classList.add("hidden");
-      dialogTarget.dataset.state = "closed";
-      modalTarget.classList.add("hidden");
-      modalTarget.dataset.state = "closed";
-    }
+    
+    // Determine current visibility state
+    const visible = dialogTarget.dataset.state === "closed";
+    
+    // Use the shared toggle method with explicitly provided elements
+    this.toggleElements(visible, {
+      dialog: dialogTarget,
+      modal: modalTarget,
+      content: contentTarget,
+      body: document.body
+    });
   }
 }


### PR DESCRIPTION
## Summary

Basically, dialog controller seems to have all of its elements that it manages within it, so its elements can be obtained directly, while sheet controller needs to use traditional JS means to get the DOM elements that might be located elsewhere.

The program first sees if DOM elements are passed in, but if not, like in the case of dialog controller, it automatically gets the static - when these elements aren't provided, in the case of dialog controller, the code automatically uses the targets identified by stimulus.