### PR TITLE
Edited bin/dev to automatically install overmind if not already installed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/bin/dev
+++ b/bin/dev
@@ -1,3 +1,8 @@
 #!/usr/bin/env sh
 
+if ! gem list overmind -i --silent; then
+  echo "Installing overmind..."
+  gem install overmind
+fi
+
 overmind start -f Procfile.dev


### PR DESCRIPTION
Very basic check, written in the style of foreman `bin/dev`, included below:
```sh
#!/usr/bin/env sh

if ! gem list foreman -i --silent; then
  echo "Installing foreman..."
  gem install foreman
fi

# Default to port 3000 if not specified
export PORT="${PORT:-3000}"

# Let the debug gem allow remote connections,
# but avoid loading until `debugger` is called
export RUBY_DEBUG_OPEN="true"
export RUBY_DEBUG_LAZY="true"

exec foreman start -f Procfile.dev "$@"
```