### PR TITLE
Alternate Fix to Ensure Overmind Exists When Running bin/dev

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/bin/setup
+++ b/bin/setup
@@ -30,4 +30,9 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
+
+  if Gem::Specification.find_all_by_name('overmind').empty?
+    puts "\n== Installing overmind =="
+    system! "gem install overmind"
+  end
 end


### PR DESCRIPTION
Another way to do #95, also closes #93.

This is the preferred way by @kmooventhan98.