### PR TITLE
Add tailwindcss-rails 4 support in generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     shadcn-ui (0.0.14)
       tailwind_merge (~> 0.12)
+      tailwindcss-rails (< 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/generators/shadcn-ui_generator.rb
+++ b/lib/generators/shadcn-ui_generator.rb
@@ -36,7 +36,7 @@ class ShadcnUiGenerator < Rails::Generators::Base
 
   def check_target_app
     puts "Checking for tailwind..."
-    puts "...tailwind found." if check_for_tailwind
+    check_for_tailwind
 
     puts "Checking for shadcn.css..."
     check_for_shadcn_css
@@ -115,12 +115,10 @@ class ShadcnUiGenerator < Rails::Generators::Base
   end
 
   def check_for_tailwind
-    tailwind_file_path = File.join(target_rails_root, "app/assets/stylesheets/application.tailwind.css")
-
-    if File.exist?(tailwind_file_path)
-      true
+    if Gem::Specification.find_all_by_name("tailwindcss-rails").any?
+      puts "...found Tailwind"
     else
-      abort "shadcn-ui requires Tailwind CSS. Please include tailwindcss-rails in your Gemfile and run `rails g tailwindcss:install` to install Tailwind CSS."
+      abort "shadcn-ui requires Tailwind CSS. Please include tailwindcss-rails in your Gemfile and run `rails tailwindcss:install` to install Tailwind CSS."
     end
   end
 
@@ -138,16 +136,18 @@ class ShadcnUiGenerator < Rails::Generators::Base
   end
 
   def check_for_shadcn_css_import
-    tailwind_file_path = File.join(target_rails_root, "app/assets/stylesheets/application.tailwind.css")
+    tailwind_file_path = File.join(target_rails_root, "app/assets/stylesheets/application.css")
 
     if File.file?(tailwind_file_path)
       matched_file = File.readlines(tailwind_file_path).any? { |s| s.include?("shadcn.css") }
       if !matched_file
-        puts "Importing shadcn.css into application.tailwind.css..."
+        puts "Importing shadcn.css into application.css..."
         insert_import_first_line(tailwind_file_path, "@import \"shadcn.css\";")
+      else
+        puts "...found shadcn.css import"
       end
     else
-      puts "application.tailwind.css does not exist."
+      puts "application.css does not exist."
     end
   end
 

--- a/spec/generators/shadcn-ui_generator_spec.rb
+++ b/spec/generators/shadcn-ui_generator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ShadcnUiGenerator, type: :generator do
     FileUtils.mkdir_p("#{rails_root}/app/helpers/components")
     FileUtils.mkdir_p("#{rails_root}/app/javascript/controllers/ui")
     FileUtils.mkdir_p("#{rails_root}/app/assets/stylesheets")
-    FileUtils.touch("#{rails_root}/app/assets/stylesheets/application.tailwind.css")
+    FileUtils.touch("#{rails_root}/app/assets/stylesheets/application.css")
   end
 
   after(:all) do
@@ -55,7 +55,7 @@ RSpec.describe ShadcnUiGenerator, type: :generator do
   end
 
   it "inserts the import line into application.tailwind.css if missing" do
-    tailwind_css_path = "#{rails_root}/app/assets/stylesheets/application.tailwind.css"
+    tailwind_css_path = "#{rails_root}/app/assets/stylesheets/application.css"
 
     generator = described_class.new([component_name, rails_root])
     generator.send(:preprocess_sources)


### PR DESCRIPTION
This pull request updates the `shadcn-ui_generator` to improve how it checks for Tailwind CSS and manages stylesheet imports, aligning the generator with more typical Rails conventions. The main focus is shifting from `application.tailwind.css` to `application.css` for stylesheet management, and improving the detection of Tailwind CSS via the gem rather than file presence.

Notably, when using the `tailwindcss-rails` gem, Rails generates and expects styles to be managed via `app/assets/stylesheets/application.css`, not `application.tailwind.css`. Relying on `application.tailwind.css` therefore diverges from the default setup produced by the gem and can lead to incorrect assumptions during generator execution.

### Key changes include:

**Tailwind CSS detection and installation:**

- Changed Tailwind CSS detection to check for the `tailwindcss-rails` gem instead of the presence of `application.tailwind.css`, providing clearer messaging and guidance if the gem is missing.
    
- This aligns detection with the actual Tailwind installation mechanism used in Rails rather than relying on a non-standard stylesheet filename.
    
- Updated the generator to no longer print a redundant message when Tailwind is found, as the check now provides its own output.
    

**Stylesheet import handling:**

- Updated the generator and related messages to use `application.css` instead of `application.tailwind.css` for checking and inserting the `shadcn.css` import.
    
- This reflects the default file generated by `tailwindcss-rails` and better matches standard Rails asset pipeline conventions.
    
- Includes improved feedback when the import is found or missing.

**Test updates:**

- Modified test setup and expectations to use `application.css` instead of `application.tailwind.css`, ensuring tests match the new generator behavior. 

**Fixes #79**
